### PR TITLE
Patch to fix potential data loss from creating a new website

### DIFF
--- a/app/src/main/kotlin/ooo/akito/webmon/ui/createentry/CreateEntryActivity.kt
+++ b/app/src/main/kotlin/ooo/akito/webmon/ui/createentry/CreateEntryActivity.kt
@@ -1,9 +1,12 @@
 package ooo.akito.webmon.ui.createentry
 
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.content.res.ColorStateList
 import android.os.Build
 import android.os.Bundle
+import android.preference.PreferenceManager
 import android.text.InputType
 import android.view.View
 import android.view.ViewTreeObserver
@@ -18,6 +21,11 @@ import ooo.akito.webmon.R
 import ooo.akito.webmon.data.db.WebSiteEntry
 import ooo.akito.webmon.data.viewmodels.MainViewModel
 import ooo.akito.webmon.databinding.ActivityCreateEntryBinding
+import ooo.akito.webmon.ui.createentry.CreateEntryActivity.PreferenceHelper.customPreference
+import ooo.akito.webmon.ui.createentry.CreateEntryActivity.PreferenceHelper.saveIsDNSChecked
+import ooo.akito.webmon.ui.createentry.CreateEntryActivity.PreferenceHelper.saveIsLaissezFaireChecked
+import ooo.akito.webmon.ui.createentry.CreateEntryActivity.PreferenceHelper.saveName
+import ooo.akito.webmon.ui.createentry.CreateEntryActivity.PreferenceHelper.saveURL
 import ooo.akito.webmon.utils.Constants
 import ooo.akito.webmon.utils.ExceptionCompanion.msgNullNotNull
 import ooo.akito.webmon.utils.Log
@@ -406,6 +414,86 @@ class CreateEntryActivity : AppCompatActivity() {
     }
   }
 
+  val CUSTOM_PREF_NAME = "Entry_data"
+
+  object PreferenceHelper {
+
+    val NAME = "NAME"
+    val URL = "URL"
+    val isDNSChecked = "DNSCheck"
+    val isLaissezFaireChecked = "LaissezCheck"
+
+    fun defaultPreference(context: Context): SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+    fun customPreference(context: Context, name: String): SharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE)
+
+    inline fun SharedPreferences.editMe(operation: (SharedPreferences.Editor) -> Unit) {
+      val editMe = edit()
+      operation(editMe)
+      editMe.apply()
+    }
+
+    var SharedPreferences.saveURL
+      get() = getString(URL, "")
+      set(value) {
+        editMe {
+          it.putString(URL, value)
+        }
+      }
+
+    var SharedPreferences.saveIsDNSChecked
+      get() = getBoolean(isDNSChecked, false)
+      set(value) {
+        editMe {
+          it.putBoolean(isDNSChecked, value)
+        }
+      }
+
+    var SharedPreferences.saveName
+      get() = getString(NAME, "")
+      set(value) {
+        editMe {
+          it.putString(NAME, value)
+        }
+      }
+
+    var SharedPreferences.saveIsLaissezFaireChecked
+      get() = getBoolean(isLaissezFaireChecked, false)
+      set(value) {
+        editMe {
+          it.putBoolean(isLaissezFaireChecked, value)
+        }
+      }
+  }
+
+  private var isSubmit_gen = false
+
+  override fun onPause() {
+    super.onPause()
+    val sp_gen = customPreference(this, CUSTOM_PREF_NAME)
+    if(isSubmit_gen){
+      sp_gen.saveName = ""
+      sp_gen.saveURL = ""
+      sp_gen.saveIsDNSChecked = false
+      sp_gen.saveIsLaissezFaireChecked = false
+    }else {
+      sp_gen.saveName = activityCreateEntryBinding.editName.text.toString()
+      sp_gen.saveURL = activityCreateEntryBinding.editUrl.text.toString()
+      sp_gen.saveIsDNSChecked = activityCreateEntryBinding.checkDNSRecords.isChecked
+      sp_gen.saveIsLaissezFaireChecked = activityCreateEntryBinding.isLaissezFaire.isChecked
+    }
+  }
+
+  override fun onResume() {
+    super.onResume()
+    val sp_gen = customPreference(this, CUSTOM_PREF_NAME)
+    activityCreateEntryBinding.editName.setText(sp_gen.saveName)
+    activityCreateEntryBinding.editUrl.setText(sp_gen.saveURL)
+    activityCreateEntryBinding.checkDNSRecords.setChecked(sp_gen.saveIsDNSChecked)
+    activityCreateEntryBinding.isLaissezFaire.setChecked(sp_gen.saveIsLaissezFaireChecked)
+    isSubmit_gen = false
+  }
+
   private fun prePopulateUIwithData(previousVersionWebsiteEntry: WebSiteEntry) {
     /*
       After adding UI elements which directly correspond to an additional property in the `WebSiteEntry` data class,
@@ -447,6 +535,7 @@ class CreateEntryActivity : AppCompatActivity() {
       val intent = Intent()
       intent.putExtra(Constants.INTENT_OBJECT, todo)
       setResult(RESULT_OK, intent)
+      isSubmit_gen = true
       if (doFinish) { finish() }
     }
   }

--- a/app/src/main/kotlin/ooo/akito/webmon/utils/PreferenceHelper.kt
+++ b/app/src/main/kotlin/ooo/akito/webmon/utils/PreferenceHelper.kt
@@ -1,0 +1,64 @@
+package ooo.akito.webmon.utils
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.preference.PreferenceManager
+
+object PreferenceHelper {
+
+  val NAME = "NAME"
+  val URL = "URL"
+  val isDNSChecked = "DNSCheck"
+  val isLaissezFaireChecked = "LaissezCheck"
+  val isOnionChecked = "OnionCheck"
+
+  fun defaultPreference(context: Context): SharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+  fun customPreference(context: Context, name: String): SharedPreferences = context.getSharedPreferences(name, Context.MODE_PRIVATE)
+
+  inline fun SharedPreferences.editMe(operation: (SharedPreferences.Editor) -> Unit) {
+    val editMe = edit()
+    operation(editMe)
+    editMe.apply()
+  }
+
+  var SharedPreferences.saveIsOnionChecked
+    get() = getBoolean(isOnionChecked, false)
+    set(value) {
+      editMe {
+        it.putBoolean(isOnionChecked, value)
+      }
+    }
+
+  var SharedPreferences.saveURL
+    get() = getString(URL, "")
+    set(value) {
+      editMe {
+        it.putString(URL, value)
+      }
+    }
+
+  var SharedPreferences.saveIsDNSChecked
+    get() = getBoolean(isDNSChecked, false)
+    set(value) {
+      editMe {
+        it.putBoolean(isDNSChecked, value)
+      }
+    }
+
+  var SharedPreferences.saveName
+    get() = getString(NAME, "")
+    set(value) {
+      editMe {
+        it.putString(NAME, value)
+      }
+    }
+
+  var SharedPreferences.saveIsLaissezFaireChecked
+    get() = getBoolean(isLaissezFaireChecked, false)
+    set(value) {
+      editMe {
+        it.putBoolean(isLaissezFaireChecked, value)
+      }
+    }
+}


### PR DESCRIPTION
# Description

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

I have added a data recovery feature during the web entry creation activity.

The motivation is to improve the user experience. When a user goes to enter a new website, if the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app), the user will lose any data they had put into the l page. This feature will automatically store and restore said data so the user does not have to fill the data again thus improving the user experience.

Dependencies I’ve added include are the shared preference and preference manager to help store the data.

<!-- Fixes # (issue) -->

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I have tested it manually but have not created test cases. I did not delete any of your code so it shouldn’t impact previous functionality.